### PR TITLE
[APP-1369] feat: silent mode, company ids filter, comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,14 @@ Options:
 
   --tu                                Target username, overrides --user
   --tp                                Target password, overrides --password
+
+  --silent, --s                             Skip interactive approval
+
+  --c, --companyIds=<id1,id2>               Uses seconary ids to filter Company Secondary Index from what is synced
+```
+
+To copy specific tables by specific company ids you would do the following:
+
+```
+./bin/thinker sync --sh <FROM> --th <TO> --sd gather --td gather --c sa0oiol9,phbq3484 --s --pt accounts,bookings,charges,comments,contacts,locations,logins,messages,policies,rooms,templates,users
 ```

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -24,24 +24,27 @@ let HELPTEXT = `
     thinker sync -h | --help
 
   Options:
-    --sh, --sourceHost=<host[:port]>    Source host, defaults to 'localhost:21015'
-    --th, --targetHost=<host[:port]>    Target host, defaults to 'localhost:21015'
-    --sd, --sourceDB=<dbName>           Source database
-    --td, --targetDB=<dbName>           Target database
+    --sh, --sourceHost=<host[:port]>          Source host, defaults to 'localhost:21015'
+    --th, --targetHost=<host[:port]>          Target host, defaults to 'localhost:21015'
+    --sd, --sourceDB=<dbName>                 Source database
+    --td, --targetDB=<dbName>                 Target database
 
-    --pt, --pickTables=<table1,table2>  Comma separated list of tables to sync (whitelist)
-    --ot, --omitTables=<table1,table2>  Comma separated list of tables to ignore (blacklist)
-                                        Note: '--pt' and '--ot' are mutually exclusive options.
+    --pt, --pickTables=<table1,table2>        Comma separated list of tables to sync (whitelist)
+    --ot, --omitTables=<table1,table2>        Comma separated list of tables to ignore (blacklist)
+                                              Note: '--pt' and '--ot' are mutually exclusive options.
 
-    --user                              Source and Target username
-    --password                          Source and Target password
+    --user                                    Source and Target username
+    --password                                Source and Target password
 
-    --su                                Source username, overrides --user
-    --sp                                Source password, overrides --password
+    --su                                      Source username, overrides --user
+    --sp                                      Source password, overrides --password
 
-    --tu                                Target username, overrides --user
-    --tp                                Target password, overrides --password
+    --tu                                      Target username, overrides --user
+    --tp                                      Target password, overrides --password
 
+    --silent, --s                             Skip interactive approval
+
+    --c, --companyIds=<id1,id2>               Uses seconary ids to filter Company Secondary Index from what is synced
 `
 
 module.exports = function *(argv) {
@@ -60,9 +63,12 @@ module.exports = function *(argv) {
   let sourcePassword = argv.sp ? argv.sp : argv.password ? argv.password : ''
   let targetUser = argv.tu ? argv.tu : argv.user ? argv.user : 'admin'
   let targetPassword = argv.tp ? argv.tp : argv.password ? argv.password : ''
+  let companyIds = argv.c ? argv.c : argv.companyIds ? argv.companyIds : null
+  const silent = argv.s ? argv.s : argv.silent ? argv.silent : null
 
   pickTables = _.isString(pickTables) ? pickTables.split(',') : null
   omitTables = _.isString(omitTables) ? omitTables.split(',') : null
+  companyIds = _.isString(companyIds) ? companyIds.split(',') : null
 
   if (argv.h || argv.help) {
     console.log(HELPTEXT)
@@ -121,16 +127,20 @@ module.exports = function *(argv) {
 
   console.log(confMessage)
 
-  let answer = yield inquirer.prompt([{
-    type: 'confirm',
-    name: 'confirmed',
-    message: 'Proceed?',
-    default: false
-  }])
+  if (!silent) {
 
-  if (!answer.confirmed) {
-    console.log(colors.red('ABORT!'))
-    return
+    let answer = yield inquirer.prompt([{
+      type: 'confirm',
+      name: 'confirmed',
+      message: 'Proceed?',
+      default: false
+    }])
+
+    if (!answer.confirmed) {
+      console.log(colors.red('ABORT!'))
+      return
+    }
+
   }
 
   startTime = moment()
@@ -192,12 +202,36 @@ module.exports = function *(argv) {
     let queue = blockingQueue()
 
     console.log(`Synchronizing ${totalRecords} records in ${table}...                                                                        `)
-    let sourceCursor = yield sr.db(sourceDB).table(table).orderBy({index: sr.asc('id')})
-      .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
-      .run({cursor: true})
-    let targetCursor = yield tr.db(targetDB).table(table).orderBy({index: tr.asc('id')})
-      .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
-      .run({cursor: true})
+    let sourceCursor
+    let targetCursor
+    if (companyIds) {
+      console.log(`Synchronizing by Companies: ${companyIds}`)
+      sourceCursor = yield sr.db(sourceDB).table(table)
+        .orderBy({index: "id"})
+        .filter(el =>
+          sr.expr(companyIds)
+          .contains(el("Company"))
+        )
+        .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
+        .run({cursor: true})
+      targetCursor = yield tr.db(targetDB).table(table)
+        .orderBy({index: "id"})
+        .filter(el =>
+          tr.expr(companyIds)
+          .contains(el("Company"))
+        )
+        .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
+        .run({cursor: true})
+    } else {
+      console.log(`Synchronizing everything`)
+      sourceCursor = yield sr.db(sourceDB).table(table)
+        .orderBy({index: sr.asc('id')})
+        .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
+        .run({cursor: true})
+      targetCursor = yield tr.db(targetDB).table(table).orderBy({index: tr.asc('id')})
+        .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
+        .run({cursor: true})
+    }
 
     let si = {}
     let ti = {}

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -44,7 +44,7 @@ let HELPTEXT = `
 
     --silent, --s                             Skip interactive approval
 
-    --c, --companyIds=<id1,id2>               Uses seconary ids to filter Company Secondary Index from what is synced
+    --c, --companyIds=<id1,id2>               Uses secondary ids to filter Company Secondary Index from what is synced
 `
 
 /** Gets a DB cursor to the items filtered by Secondary Index Company
@@ -63,7 +63,7 @@ function getByCompany(connection, database, table, companyIds) {
     .run({ cursor: true })
 }
 
-/** Gets a DB cursos to the items of a table
+/** Gets a DB cursor to the items of a table
  * @param {*} connection Your connection object to rethinkdb
  * @param {string} database Database name
  * @param {string} table Table name

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -47,6 +47,34 @@ let HELPTEXT = `
     --c, --companyIds=<id1,id2>               Uses seconary ids to filter Company Secondary Index from what is synced
 `
 
+/** Gets a DB cursor to the items filtered by Secondary Index Company
+ * @param {*} connection Your connection object to rethinkdb
+ * @param {string} database Database name
+ * @param {string} table Table name
+ * @param {string[]} companyIds Array of company ids 
+ */
+function getByCompany(connection, database, table, companyIds) {
+  return connection.db(database).table(table)
+    .orderBy({index: "id"})
+    .filter(doc =>
+      connection.expr(companyIds).contains(doc("Company"))
+    )
+    .map(function (row) { return {id: row('id'), hash: connection.uuid(row.toJSON())} })
+    .run({ cursor: true })
+}
+
+/** Gets a DB cursos to the items of a table
+ * @param {*} connection Your connection object to rethinkdb
+ * @param {string} database Database name
+ * @param {string} table Table name
+ */
+function getInOrder(connection, database, table) {
+  return connection.db(database).table(table)
+    .orderBy({index: connection.asc('id')})
+    .map(function (row) { return {id: row('id'), hash: connection.uuid(row.toJSON())} })
+    .run({cursor: true})
+}
+
 module.exports = function *(argv) {
   let startTime
   let sHost = argv.sh ? argv.sh : argv.sourceHost ? argv.sourceHost : 'localhost:28015'
@@ -204,33 +232,15 @@ module.exports = function *(argv) {
     console.log(`Synchronizing ${totalRecords} records in ${table}...                                                                        `)
     let sourceCursor
     let targetCursor
+
     if (companyIds) {
       console.log(`Synchronizing by Companies: ${companyIds}`)
-      sourceCursor = yield sr.db(sourceDB).table(table)
-        .orderBy({index: "id"})
-        .filter(el =>
-          sr.expr(companyIds)
-          .contains(el("Company"))
-        )
-        .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
-        .run({cursor: true})
-      targetCursor = yield tr.db(targetDB).table(table)
-        .orderBy({index: "id"})
-        .filter(el =>
-          tr.expr(companyIds)
-          .contains(el("Company"))
-        )
-        .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
-        .run({cursor: true})
+      sourceCursor = yield getByCompany(sr, sourceDB, table, companyIds)
+      targetCursor = yield getByCompany(tr, targetDB, table, companyIds)
     } else {
       console.log(`Synchronizing everything`)
-      sourceCursor = yield sr.db(sourceDB).table(table)
-        .orderBy({index: sr.asc('id')})
-        .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
-        .run({cursor: true})
-      targetCursor = yield tr.db(targetDB).table(table).orderBy({index: tr.asc('id')})
-        .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
-        .run({cursor: true})
+      sourceCursor = yield getInOrder(sr, sourceDB, table)
+      targetCursor = yield getInOrder(tr, targetDB, table)
     }
 
     let si = {}


### PR DESCRIPTION
Adds a silent mode and a flag to only copy data from certain companies

New flags

  - **c** or **companyIds** Comma separated list of company ids
  - **s** or **silent** Run without waiting for user input (might be renamed to autoApprove)

Usage examples

```
thinker sync --sh 127.0.0.1:28025 --th 127.0.0.1:28015 --sd gather --td gather --c sa0oiol9,phbq3484 --s --pt accounts,bookings,charges,comments,contacts,locations,logins,messages,policies,rooms,templates,users
```

or all tables

```
sync --sh 127.0.0.1:28025 --th 127.0.0.1:28015 --sd gather --td gather --c sa0oiol9,phbq3484 --s
```