### PR TITLE
[APP-1812] feat: thinker needs indexesOnly

### DIFF
--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -45,6 +45,8 @@ let HELPTEXT = `
     --silent, --s                             Skip interactive approval
 
     --c, --companyIds=<id1,id2>               Uses secondary ids to filter Company Secondary Index from what is synced
+
+    --indexesOnly                             Just create indexes
 `
 
 /** Gets a DB cursor to the items filtered by Secondary Index Company
@@ -93,6 +95,7 @@ module.exports = function *(argv) {
   let targetPassword = argv.tp ? argv.tp : argv.password ? argv.password : ''
   let companyIds = argv.c ? argv.c : argv.companyIds ? argv.companyIds : null
   const silent = argv.s ? argv.s : argv.silent ? argv.silent : null
+  const indexesOnly = argv.indexesOnly ? argv.indexesOnly : null
 
   pickTables = _.isString(pickTables) ? pickTables.split(',') : null
   omitTables = _.isString(omitTables) ? omitTables.split(',') : null
@@ -218,92 +221,94 @@ module.exports = function *(argv) {
     yield tr.db(targetDB).table(table).indexWait().run()
   }, 999)
 
-  for (let table of tablesToSync) {
-    let totalRecords = yield sr.db(sourceDB).table(table).count().run()
-    let recordsProcessed = 0
-    let lastRecordsProcessed = 0
-    let perfStat = []
-    let statusInterval = 500
-    let created = 0
-    let updated = 0
-    let deleted = 0
-    let queue = blockingQueue()
-
-    console.log(`Synchronizing ${totalRecords} records in ${table}...                                                                        `)
-    let sourceCursor
-    let targetCursor
-
-    if (companyIds) {
-      console.log(`Synchronizing by Companies: ${companyIds}`)
-      sourceCursor = yield getByCompany(sr, sourceDB, table, companyIds)
-      targetCursor = yield getByCompany(tr, targetDB, table, companyIds)
-    } else {
-      console.log(`Synchronizing everything`)
-      sourceCursor = yield getInOrder(sr, sourceDB, table)
-      targetCursor = yield getInOrder(tr, targetDB, table)
-    }
-
-    let si = {}
-    let ti = {}
-
-    si = yield getNextIdx(sourceCursor, si)
-    ti = yield getNextIdx(targetCursor, ti)
-
-    co(function *() {
-      let pc = 0
-      while (pc < 100) {
-        perfStat.unshift(recordsProcessed - lastRecordsProcessed)
-        while (perfStat.length > 30) {
-          perfStat.pop()
-        }
-        let rps = (_.reduce(perfStat, (a, b) => a + b) / (perfStat.length * (statusInterval / 1000))).toFixed(1)
-        pc = ((recordsProcessed / totalRecords) * 100).toFixed(1)
-        process.stdout.write(` RECORDS SYNCHRONIZED: ${recordsProcessed} | ${rps} sec. | %${pc} | created ${created} | updated ${updated} | deleted ${deleted} | concurrency ${queue.concurrency}                    \r`)
-        lastRecordsProcessed = recordsProcessed
-
-        yield Promise.delay(statusInterval)
+  if (!indexesOnly) {
+    for (let table of tablesToSync) {
+      let totalRecords = yield sr.db(sourceDB).table(table).count().run()
+      let recordsProcessed = 0
+      let lastRecordsProcessed = 0
+      let perfStat = []
+      let statusInterval = 500
+      let created = 0
+      let updated = 0
+      let deleted = 0
+      let queue = blockingQueue()
+  
+      console.log(`Synchronizing ${totalRecords} records in ${table}...                                                                        `)
+      let sourceCursor
+      let targetCursor
+  
+      if (companyIds) {
+        console.log(`Synchronizing by Companies: ${companyIds}`)
+        sourceCursor = yield getByCompany(sr, sourceDB, table, companyIds)
+        targetCursor = yield getByCompany(tr, targetDB, table, companyIds)
+      } else {
+        console.log(`Synchronizing everything`)
+        sourceCursor = yield getInOrder(sr, sourceDB, table)
+        targetCursor = yield getInOrder(tr, targetDB, table)
       }
-    })
-
-    while (si.id !== Infinity || ti.id !== Infinity) {
-      const cmp = compareValues(si.id, ti.id)
-
-      if (cmp === 0) {  // si.id === ti.id  ->  check hashes
-        let sid = si.id
-        let tid = ti.id
-        if (si.hash !== ti.hash) {
+  
+      let si = {}
+      let ti = {}
+  
+      si = yield getNextIdx(sourceCursor, si)
+      ti = yield getNextIdx(targetCursor, ti)
+  
+      co(function *() {
+        let pc = 0
+        while (pc < 100) {
+          perfStat.unshift(recordsProcessed - lastRecordsProcessed)
+          while (perfStat.length > 30) {
+            perfStat.pop()
+          }
+          let rps = (_.reduce(perfStat, (a, b) => a + b) / (perfStat.length * (statusInterval / 1000))).toFixed(1)
+          pc = ((recordsProcessed / totalRecords) * 100).toFixed(1)
+          process.stdout.write(` RECORDS SYNCHRONIZED: ${recordsProcessed} | ${rps} sec. | %${pc} | created ${created} | updated ${updated} | deleted ${deleted} | concurrency ${queue.concurrency}                    \r`)
+          lastRecordsProcessed = recordsProcessed
+  
+          yield Promise.delay(statusInterval)
+        }
+      })
+  
+      while (si.id !== Infinity || ti.id !== Infinity) {
+        const cmp = compareValues(si.id, ti.id)
+  
+        if (cmp === 0) {  // si.id === ti.id  ->  check hashes
+          let sid = si.id
+          let tid = ti.id
+          if (si.hash !== ti.hash) {
+            yield queue.push(function *() {
+              let record = yield sr.db(sourceDB).table(table).get(sid).run({timeFormat: 'raw'})
+              yield tr.db(targetDB).table(table).get(tid).replace(record).run()
+              updated += 1
+            })
+          }
+          si = yield getNextIdx(sourceCursor, si)
+          ti = yield getNextIdx(targetCursor, ti)
+          recordsProcessed += 1
+        } else if (cmp < 0) {  // si.id < ti.id  ->  copy si
+          let sid = si.id
           yield queue.push(function *() {
             let record = yield sr.db(sourceDB).table(table).get(sid).run({timeFormat: 'raw'})
-            yield tr.db(targetDB).table(table).get(tid).replace(record).run()
-            updated += 1
+            yield tr.db(targetDB).table(table).insert(record).run()
+            created += 1
           })
+          si = yield getNextIdx(sourceCursor, si)
+          recordsProcessed += 1
+        } else if (cmp > 0) {  // si.id > ti.id  ->  delete ti
+          let tid = ti.id
+          yield queue.push(function *() {
+            yield tr.db(targetDB).table(table).get(tid).delete().run()
+          })
+          ti = yield getNextIdx(targetCursor, ti)
+          deleted += 1
+        } else {
+          console.log(colors.red(`ERROR! Cannot sync, encountered uncomparable PKs`))
+          break
         }
-        si = yield getNextIdx(sourceCursor, si)
-        ti = yield getNextIdx(targetCursor, ti)
-        recordsProcessed += 1
-      } else if (cmp < 0) {  // si.id < ti.id  ->  copy si
-        let sid = si.id
-        yield queue.push(function *() {
-          let record = yield sr.db(sourceDB).table(table).get(sid).run({timeFormat: 'raw'})
-          yield tr.db(targetDB).table(table).insert(record).run()
-          created += 1
-        })
-        si = yield getNextIdx(sourceCursor, si)
-        recordsProcessed += 1
-      } else if (cmp > 0) {  // si.id > ti.id  ->  delete ti
-        let tid = ti.id
-        yield queue.push(function *() {
-          yield tr.db(targetDB).table(table).get(tid).delete().run()
-        })
-        ti = yield getNextIdx(targetCursor, ti)
-        deleted += 1
-      } else {
-        console.log(colors.red(`ERROR! Cannot sync, encountered uncomparable PKs`))
-        break
       }
+  
+      yield tr.db(targetDB).table(table).sync().run()
     }
-
-    yield tr.db(targetDB).table(table).sync().run()
   }
 
   console.log(colors.green(`DONE! Completed in ${startTime.fromNow(true)}`))


### PR DESCRIPTION
When spinning up a new Cluster or Production Clone, we need to create indexes based on a remote database, which is a massive operation on the new Cluster but not on the Remote DB. To automate this process we set up a late stage: **Create Indexes Only**, which might take a day.

Once Index Creation is done then we can set up the cron job to do DB Syncing.