### PR TITLE
[APP-1812] Improving DONE message

### DIFF
--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -355,8 +355,14 @@ module.exports = function *(argv) {
       yield tr.db(targetDB).table(table).sync().run()
     }
   }
-
-  logger.info(colors.green(`DONE! Completed in ${startTime.fromNow(true)}`))
+  let msg = `DONE! Completed in ${startTime.fromNow(true)}`
+  if (pickTables) {
+    msg = `${msg} for Tables: ${JSON.stringify(pickTables)}`
+  }
+  if (omitTables) {
+    msg = `${msg} without Tables: ${JSON.stringify(omitTables)}`
+  }
+  logger.info(colors.green(msg))
 }
 
 var getNextIdx = function *(cursor, idx) {


### PR DESCRIPTION
Executing thinker in Parallel makes logs confusing since we can't match the Synchronizing message with the Done message. With this log message we can match log outputs 1-1

Example

![image](https://user-images.githubusercontent.com/779325/48719787-48bdaf00-ebec-11e8-8882-3cd44c3a027e.png)
