### PR TITLE
[APP-1812] Rethink hangs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,5 +40,6 @@ module.exports = function (argv) {
   .catch(function (err) {
     console.log('ERROR')
     console.log(err)
+    process.exit(1)
   })
 }


### PR DESCRIPTION
If there is a connection failure `thinker` doesn't crash, making everything appear OK. Instead of doing that, we will crash `thinker` in order to handle it at a higher level (AWS).