### PR TITLE
[APP-1926] Adding extra time to error retry

### DIFF
--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -179,6 +179,7 @@ module.exports = function *(argv) {
     user: sourceUser,
     password: sourcePassword,
     timeout: 10,
+    timeoutError: 60000, // Wait 60 seconds before trying to reconnect in case of an error
     timeoutGb: 600,
     buffer: buffer,
     max: max,
@@ -251,6 +252,7 @@ module.exports = function *(argv) {
     user: targetUser,
     password: targetPassword,
     timeout: 10,
+    timeoutError: 60000, // Wait 60 seconds before trying to reconnect in case of an error
     timeoutGb: 600,
     buffer: buffer,
     max: max,

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
     "test": "echo 'no tests yet'"
   },
   "dependencies": {
-    "bluebird": "^3.4.1",
-    "co": "^4.6.0",
-    "co-parallel": "^1.0.0",
-    "colors": "^1.1.2",
-    "inquirer": "^1.1.2",
-    "lodash": "^4.14.0",
-    "minimist": "^1.2.0",
-    "moment": "^2.14.1",
-    "require-all": "^2.0.0",
-    "rethinkdbdash": "^2.3.19",
-    "verbalize": "^0.2.0"
+    "bluebird": "3.5.3",
+    "co": "4.6.0",
+    "co-parallel": "1.0.0",
+    "colors": "1.1.2",
+    "inquirer": "1.1.2",
+    "lodash": "4.14.0",
+    "minimist": "1.2.0",
+    "moment": "2.14.1",
+    "require-all": "2.0.0",
+    "rethinkdbdash": "2.3.31",
+    "verbalize": "0.2.0"
   },
   "devDependencies": {},
   "standard": {


### PR DESCRIPTION
  - Thinker is greedy when there are errors and retries after 1 second, instead we will retry after 1 minute.
  - Upgrade rethinkdbdash for some bug fixes
  - Freeze dependencies